### PR TITLE
Add Monad superclass for parameters to UnsafeTx

### DIFF
--- a/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
@@ -23,21 +23,24 @@ import qualified Squeal.PostgreSQL as Squeal
 
 type SquealM db0 db1 = PQ db0 db1 TxM
 
-unsafeSquealIOTx :: PQ db0 db1 IO a -> SquealM db0 db1 a
+unsafeSquealIOTx :: (db0 ~ db1) => PQ db0 db1 IO a -> SquealM db0 db1 a
 unsafeSquealIOTx = unsafeIOTx
 
 unsafeSquealIOTx1
-  :: (x1 -> PQ db0 db1 IO a)
+  :: (db0 ~ db1)
+  => (x1 -> PQ db0 db1 IO a)
   -> x1 -> SquealM db0 db1 a
 unsafeSquealIOTx1 f x1 = unsafeSquealIOTx $ f x1
 
 unsafeSquealIOTx2
-  :: (x1 -> x2 -> PQ db0 db1 IO a)
+  :: (db0 ~ db1)
+  => (x1 -> x2 -> PQ db0 db1 IO a)
   -> x1 -> x2 -> SquealM db0 db1 a
 unsafeSquealIOTx2 f x1 x2 = unsafeSquealIOTx $ f x1 x2
 
 unsafeSquealIOTx3
-  :: (x1 -> x2 -> x3 -> PQ db0 db1 IO a)
+  :: (db0 ~ db1)
+  => (x1 -> x2 -> x3 -> PQ db0 db1 IO a)
   -> x1 -> x2 -> x3 -> SquealM db0 db1 a
 unsafeSquealIOTx3 f x1 x2 x3 = unsafeSquealIOTx $ f x1 x2 x3
 
@@ -200,7 +203,7 @@ instance Tx (SquealM db0 db1) where
   type TxEnv (SquealM db0 db1) = Connection
   tx conn x = evalPQ x (Squeal.K conn)
 
-instance (UnsafeTx io t) => UnsafeTx (PQ db0 db1 io) (PQ db0 db1 t) where
+instance (UnsafeTx io t, db0 ~ db1) => UnsafeTx (PQ db0 db1 io) (PQ db0 db1 t) where
   unsafeIOTx x = PQ \kConn -> unsafeIOTx (Squeal.unPQ x kConn)
 
 instance (UnsafeUnliftTx t, db0 ~ db1) => UnsafeUnliftTx (PQ db0 db1 t) where

--- a/src/Database/PostgreSQL/Tx.hs
+++ b/src/Database/PostgreSQL/Tx.hs
@@ -22,7 +22,7 @@ import Database.PostgreSQL.Tx.Internal
 -- implementation monad from the various @postgresql-tx-*@ packages.
 --
 -- @since 0.2.0.0
-throwExceptionTx :: (MonadIO io, UnsafeTx io t, Exception e) => e -> t a
+throwExceptionTx :: (UnsafeTx io t, Exception e) => e -> t a
 throwExceptionTx ex = unsafeIOTx $ liftIO $ throwIO ex
 
 -- | Catch an exception and map it to another exception type before rethrowing.

--- a/src/Database/PostgreSQL/Tx/Internal.hs
+++ b/src/Database/PostgreSQL/Tx/Internal.hs
@@ -76,7 +76,7 @@ instance Tx (ReaderT r TxM) where
 -- of 'TxM').
 --
 -- @since 0.1.0.0
-class UnsafeTx (io :: * -> *) (t :: * -> *) | t -> io where
+class (Monad io, Monad t) => UnsafeTx (io :: * -> *) (t :: * -> *) | t -> io where
   -- | Converts an @io@ action to a @t@, which will be some form of 'TxM'. Use
   -- this function with care - arbitrary 'IO' should only be run within a
   -- transaction when truly necessary.

--- a/src/Database/PostgreSQL/Tx/Internal.hs
+++ b/src/Database/PostgreSQL/Tx/Internal.hs
@@ -76,7 +76,7 @@ instance Tx (ReaderT r TxM) where
 -- of 'TxM').
 --
 -- @since 0.1.0.0
-class (Monad io, Monad t) => UnsafeTx (io :: * -> *) (t :: * -> *) | t -> io where
+class (MonadIO io, Monad t) => UnsafeTx (io :: * -> *) (t :: * -> *) | t -> io where
   -- | Converts an @io@ action to a @t@, which will be some form of 'TxM'. Use
   -- this function with care - arbitrary 'IO' should only be run within a
   -- transaction when truly necessary.


### PR DESCRIPTION
While the `Monad` superclass so far isn't strictly necessary on `UnsafeTx`, it communicates our intent better in that we do expect these parameters to be monads.