### PR TITLE
Add unsafeLiftIOTx

### DIFF
--- a/src/Database/PostgreSQL/Tx/Internal.hs
+++ b/src/Database/PostgreSQL/Tx/Internal.hs
@@ -93,6 +93,12 @@ instance UnsafeTx IO TxM where
 instance (UnsafeTx io t) => UnsafeTx (ReaderT r io) (ReaderT r t) where
   unsafeIOTx = mapReaderT unsafeIOTx
 
+-- | A variant of 'liftIO' to promote 'IO' directly to some variant of 'TxM'.
+--
+-- @since 0.2.0.0
+unsafeLiftIOTx :: (UnsafeTx io t, MonadIO io) => IO a -> t a
+unsafeLiftIOTx = unsafeIOTx . liftIO
+
 -- | Run a specific database library implementation monad in 'IO', given that
 -- monad's runtime environment. Use of this function outside of test suites
 -- should be rare.

--- a/src/Database/PostgreSQL/Tx/Unsafe.hs
+++ b/src/Database/PostgreSQL/Tx/Unsafe.hs
@@ -5,6 +5,7 @@ module Database.PostgreSQL.Tx.Unsafe
     -- ** Operations
     unsafeRunIOInTxM
   , UnsafeTx(unsafeIOTx)
+  , unsafeLiftIOTx
   , unsafeReaderIOTx
   , UnsafeUnliftTx(unsafeWithRunInIOTx)
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,9 @@
 
 packages:
 - completed:
+    cabal-file:
+      size: 4959
+      sha256: 8891f4eea893607c6e500d73f5f095e11f5bc7c0c20467e6b9040a3e1be039a5
     name: postgresql-query
     version: 3.5.0
     git: https://github.com/Simspace/postgresql-query


### PR DESCRIPTION
Useful when dealing with `MonadIO` things that need to be lifted to an arbitrary `Tx`.