### PR TITLE
Proposal: Use SquealTxM in favor of SquealSchemas

### DIFF
--- a/example/package.yaml
+++ b/example/package.yaml
@@ -15,6 +15,7 @@ ghc-options:
 dependencies:
 - base >= 4.7 && < 5
 - bytestring
+- hspec
 - monad-logger
 - postgresql-libpq
 - postgresql-query

--- a/example/test/Example/PgQuery/Internal/DB.hs
+++ b/example/test/Example/PgQuery/Internal/DB.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE RankNTypes #-}
 module Example.PgQuery.Internal.DB where
 
-import Database.PostgreSQL.Tx.Query (PgQueryM)
-
-data Handle = Handle
+data Handle f = Handle
   { insertTwoMessages
-      :: String -> String -> PgQueryM (Int, Int)
+      :: String -> String -> f (Int, Int)
   , fetchTwoMessages
-      :: Int -> Int -> PgQueryM (Maybe String, Maybe String)
+      :: Int -> Int -> f (Maybe String, Maybe String)
 
   , close :: IO ()
   }

--- a/example/test/Example/PgQuery/Internal/Queries.hs
+++ b/example/test/Example/PgQuery/Internal/Queries.hs
@@ -6,11 +6,12 @@
 {-# LANGUAGE RankNTypes #-}
 module Example.PgQuery.Internal.Queries where
 
+import Database.PostgreSQL.Tx (TxM)
 import qualified Database.PostgreSQL.Tx.Query as Tx
 import qualified Control.Exception as Exception
 import qualified Example.PgQuery.Internal.DB as DB
 
-new :: IO DB.Handle
+new :: (Tx.PgQueryEnv r) => IO (DB.Handle (TxM r))
 new =
   pure DB.Handle
     { DB.insertTwoMessages
@@ -19,7 +20,7 @@ new =
     , DB.close = mempty
     }
 
-withHandle :: (DB.Handle -> IO a) -> IO a
+withHandle :: (Tx.PgQueryEnv r) => ((DB.Handle (TxM r)) -> IO a) -> IO a
 withHandle = Exception.bracket new DB.close
 
 insertTwoMessages

--- a/example/test/Example/PgSimple/Internal/DB.hs
+++ b/example/test/Example/PgSimple/Internal/DB.hs
@@ -2,11 +2,9 @@
 {-# LANGUAGE RankNTypes #-}
 module Example.PgSimple.Internal.DB where
 
-import Database.PostgreSQL.Tx.Simple (PgSimpleM)
-
-data Handle = Handle
-  { insertMessage :: String -> PgSimpleM Int
-  , fetchMessage :: Int -> PgSimpleM (Maybe String)
+data Handle f = Handle
+  { insertMessage :: String -> f Int
+  , fetchMessage :: Int -> f (Maybe String)
 
   , close :: IO ()
   }

--- a/example/test/Example/PgSimple/Internal/Queries.hs
+++ b/example/test/Example/PgSimple/Internal/Queries.hs
@@ -7,12 +7,13 @@
 {-# LANGUAGE RankNTypes #-}
 module Example.PgSimple.Internal.Queries where
 
+import Database.PostgreSQL.Tx (TxM)
 import qualified Control.Exception as Exception
 import qualified Database.PostgreSQL.Simple as PG.Simple
 import qualified Database.PostgreSQL.Tx.Simple as Tx
 import qualified Example.PgSimple.Internal.DB as DB
 
-new :: IO DB.Handle
+new :: (Tx.PgSimpleEnv r) => IO (DB.Handle (TxM r))
 new =
   pure DB.Handle
     { DB.insertMessage
@@ -21,7 +22,7 @@ new =
     , DB.close = mempty
     }
 
-withHandle :: (DB.Handle -> IO a) -> IO a
+withHandle :: (Tx.PgSimpleEnv r) => ((DB.Handle (TxM r)) -> IO a) -> IO a
 withHandle = Exception.bracket new DB.close
 
 insertMessage :: String -> Tx.PgSimpleM Int

--- a/example/test/Example/Squeal/Internal/DB.hs
+++ b/example/test/Example/Squeal/Internal/DB.hs
@@ -3,15 +3,12 @@
 module Example.Squeal.Internal.DB where
 
 import Database.PostgreSQL.Tx.Squeal (SquealM)
-import Example.Squeal.Internal.Schema (Schemas)
-
-type M a = SquealM Schemas Schemas a
 
 data Handle = Handle
   { insertThreeMessages
-      :: String -> String -> String -> M (Int, Int, Int)
+      :: String -> String -> String -> SquealM (Int, Int, Int)
   , fetchThreeMessages
-      :: Int -> Int -> Int -> M (Maybe String, Maybe String, Maybe String)
+      :: Int -> Int -> Int -> SquealM (Maybe String, Maybe String, Maybe String)
 
   , close :: IO ()
   }

--- a/example/test/Example/Squeal/Internal/DB.hs
+++ b/example/test/Example/Squeal/Internal/DB.hs
@@ -2,13 +2,11 @@
 {-# LANGUAGE RankNTypes #-}
 module Example.Squeal.Internal.DB where
 
-import Database.PostgreSQL.Tx.Squeal (SquealM)
-
-data Handle = Handle
+data Handle f = Handle
   { insertThreeMessages
-      :: String -> String -> String -> SquealM (Int, Int, Int)
+      :: String -> String -> String -> f (Int, Int, Int)
   , fetchThreeMessages
-      :: Int -> Int -> Int -> SquealM (Maybe String, Maybe String, Maybe String)
+      :: Int -> Int -> Int -> f (Maybe String, Maybe String, Maybe String)
 
   , close :: IO ()
   }

--- a/example/test/Example/Squeal/Internal/DB.hs
+++ b/example/test/Example/Squeal/Internal/DB.hs
@@ -5,7 +5,7 @@ module Example.Squeal.Internal.DB where
 import Database.PostgreSQL.Tx.Squeal (SquealM)
 import Example.Squeal.Internal.Schema (Schemas)
 
-type M a = SquealM Schemas a
+type M a = SquealM Schemas Schemas a
 
 data Handle = Handle
   { insertThreeMessages

--- a/example/test/Example/Squeal/Internal/Queries.hs
+++ b/example/test/Example/Squeal/Internal/Queries.hs
@@ -34,7 +34,7 @@ insertThreeMessages s1 s2 s3 = do
     rows -> error $ "Expected exactly 3 rows, got " <> show (length rows)
   where
   go :: DB.M [Int]
-  go = executeParams stmt (s1, s2, s3) >>= getRows @Schemas
+  go = executeParams stmt (s1, s2, s3) >>= getRows
 
   stmt :: Statement Schemas (String, String, String) Int
   stmt = Manipulation genericParams rowDecoder insertIntoFoo
@@ -62,7 +62,7 @@ fetchThreeMessages k1 k2 k3 = do
     )
   where
   go :: DB.M [(Int, String)]
-  go = executeParams stmt params >>= getRows @Schemas
+  go = executeParams stmt params >>= getRows
 
   params :: (Int32, Int32, Int32)
   params =

--- a/example/test/Example/Squeal/Internal/Queries.hs
+++ b/example/test/Example/Squeal/Internal/Queries.hs
@@ -9,12 +9,13 @@
 module Example.Squeal.Internal.Queries where
 
 import Data.Int (Int32)
+import Database.PostgreSQL.Tx (TxM)
 import Database.PostgreSQL.Tx.Squeal
 import Example.Squeal.Internal.Schema (Schemas)
 import qualified Control.Exception as Exception
 import qualified Example.Squeal.Internal.DB as DB
 
-new :: IO DB.Handle
+new :: (SquealEnv r) => IO (DB.Handle (TxM r))
 new =
   pure DB.Handle
     { DB.insertThreeMessages
@@ -23,7 +24,7 @@ new =
     , DB.close = mempty
     }
 
-withHandle :: (DB.Handle -> IO a) -> IO a
+withHandle :: (SquealEnv r) => ((DB.Handle (TxM r)) -> IO a) -> IO a
 withHandle = Exception.bracket new DB.close
 
 insertThreeMessages

--- a/example/test/Example/Squeal/Internal/Queries.hs
+++ b/example/test/Example/Squeal/Internal/Queries.hs
@@ -27,13 +27,12 @@ withHandle :: (DB.Handle -> IO a) -> IO a
 withHandle = Exception.bracket new DB.close
 
 insertThreeMessages
-  :: String -> String -> String -> DB.M (Int, Int, Int)
-insertThreeMessages s1 s2 s3 = do
+  :: String -> String -> String -> SquealM (Int, Int, Int)
+insertThreeMessages s1 s2 s3 = fromSquealTxM do
   go >>= \case
     [k1, k2, k3] -> pure (k1, k2, k3)
     rows -> error $ "Expected exactly 3 rows, got " <> show (length rows)
   where
-  go :: DB.M [Int]
   go = executeParams stmt (s1, s2, s3) >>= getRows
 
   stmt :: Statement Schemas (String, String, String) Int
@@ -52,8 +51,8 @@ insertThreeMessages s1 s2 s3 = do
       (Returning_ #id)
 
 fetchThreeMessages
-  :: Int -> Int -> Int -> DB.M (Maybe String, Maybe String, Maybe String)
-fetchThreeMessages k1 k2 k3 = do
+  :: Int -> Int -> Int -> SquealM (Maybe String, Maybe String, Maybe String)
+fetchThreeMessages k1 k2 k3 = fromSquealTxM do
   rows <- go
   pure
     ( lookup k1 rows
@@ -61,7 +60,6 @@ fetchThreeMessages k1 k2 k3 = do
     , lookup k3 rows
     )
   where
-  go :: DB.M [(Int, String)]
   go = executeParams stmt params >>= getRows
 
   params :: (Int32, Int32, Int32)

--- a/example/test/Test.hs
+++ b/example/test/Test.hs
@@ -19,7 +19,7 @@ import Control.Monad.Logger (LoggingT(LoggingT), runStderrLoggingT)
 import Database.PostgreSQL.Tx (TxM)
 import Database.PostgreSQL.Tx.HEnv (HEnv)
 import Database.PostgreSQL.Tx.Query (Logger)
-import Database.PostgreSQL.Tx.Squeal (SquealConnection, fromSquealTxM)
+import Database.PostgreSQL.Tx.Squeal (SquealConnection)
 import Test.Hspec
 import qualified Database.PostgreSQL.Simple as PG.Simple
 import qualified Database.PostgreSQL.Tx.HEnv as HEnv
@@ -89,10 +89,9 @@ demo pgSimpleDB pgQueryDB squealDB = do
   (k2, k3) <- Example.PgQuery.insertTwoMessages pgQueryDB "pg-query: sup" "pg-query: wut"
   ms2 <- Example.PgSimple.fetchMessage pgSimpleDB k2
   (ms1, ms3) <- Example.PgQuery.fetchTwoMessages pgQueryDB k1 k3
-  fromSquealTxM do
-    (k4, k5, k6) <- Example.Squeal.insertThreeMessages squealDB "squeal: nuthin" "squeal: ye" "squeal: k bye"
-    (ms4, ms5, ms6) <- Example.Squeal.fetchThreeMessages squealDB k4 k5 k6
-    pure (ms1, ms2, ms3, ms4, ms5, ms6)
+  (k4, k5, k6) <- Example.Squeal.insertThreeMessages squealDB "squeal: nuthin" "squeal: ye" "squeal: k bye"
+  (ms4, ms5, ms6) <- Example.Squeal.fetchThreeMessages squealDB k4 k5 k6
+  pure (ms1, ms2, ms3, ms4, ms5, ms6)
 
 withAppEnv :: (AppEnv -> IO a) -> IO a
 withAppEnv f = do

--- a/example/test/Test.hs
+++ b/example/test/Test.hs
@@ -73,9 +73,9 @@ type AppEnv =
      ]
 
 demo
-  :: Example.PgSimple.Handle
-  -> Example.PgQuery.Handle
-  -> Example.Squeal.Handle
+  :: Example.PgSimple.Handle AppM
+  -> Example.PgQuery.Handle AppM
+  -> Example.Squeal.Handle AppM
   -> AppM
       ( Maybe String
       , Maybe String

--- a/squeal/compat/simple/src/Database/PostgreSQL/Tx/Squeal/Compat/Simple.hs
+++ b/squeal/compat/simple/src/Database/PostgreSQL/Tx/Squeal/Compat/Simple.hs
@@ -19,5 +19,6 @@ import qualified Database.PostgreSQL.Simple.Internal as Simple.Internal
 -- @since 0.1.0.0
 withSquealConnection :: Simple.Connection -> (SquealConnection -> IO a) -> IO a
 withSquealConnection conn f = do
-  libpqConn <- Concurrent.readMVar $ Simple.Internal.connectionHandle conn
-  f $ UnsafeSquealConnection ($ libpqConn)
+  f $ UnsafeSquealConnection
+    $ Concurrent.readMVar
+    $ Simple.Internal.connectionHandle conn

--- a/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
@@ -8,7 +8,7 @@
 module Database.PostgreSQL.Tx.Squeal
   ( SquealEnv
   , SquealM
-  , SquealSchemas(SquealSchemas)
+  , SquealTxM(SquealTxM, fromSquealTxM)
   , SquealConnection
   , mkSquealConnection
   , module Database.PostgreSQL.Tx.Squeal
@@ -27,93 +27,93 @@ import qualified Squeal.PostgreSQL as Squeal
 -- | Analogue of 'Squeal.getRow'.
 --
 -- @since 0.1.0.0
-getRow :: forall db r y. (SquealEnv db r) => LibPQ.Row -> Result y -> TxM r y
-getRow = unsafeSquealIOTxM2 @db Squeal.getRow
+getRow :: LibPQ.Row -> Result y -> SquealM db db y
+getRow = unsafeSquealIOTxM2 Squeal.getRow
 
 -- | Analogue of 'Squeal.firstRow'.
 --
 -- @since 0.1.0.0
-firstRow :: forall db r y. (SquealEnv db r) => Result y -> TxM r (Maybe y)
-firstRow = unsafeSquealIOTxM1 @db Squeal.firstRow
+firstRow :: Result y -> SquealM db db (Maybe y)
+firstRow = unsafeSquealIOTxM1 Squeal.firstRow
 
 -- | Analogue of 'Squeal.getRows'.
 --
 -- @since 0.1.0.0
-getRows :: forall db r y. (SquealEnv db r) => Result y -> TxM r [y]
-getRows = unsafeSquealIOTxM1 @db Squeal.getRows
+getRows :: Result y -> SquealM db db [y]
+getRows = unsafeSquealIOTxM1 Squeal.getRows
 
 -- | Analogue of 'Squeal.nextRow'.
 --
 -- @since 0.1.0.0
-nextRow :: forall db r y. (SquealEnv db r) => LibPQ.Row -> Result y -> LibPQ.Row -> TxM r (Maybe (LibPQ.Row, y))
-nextRow = unsafeSquealIOTxM3 @db Squeal.nextRow
+nextRow :: LibPQ.Row -> Result y -> LibPQ.Row -> SquealM db db (Maybe (LibPQ.Row, y))
+nextRow = unsafeSquealIOTxM3 Squeal.nextRow
 
 -- | Analogue of 'Squeal.ntuples'.
 --
 -- @since 0.1.0.0
-ntuples :: forall db r y. (SquealEnv db r) => Result y -> TxM r LibPQ.Row
-ntuples = unsafeSquealIOTxM1 @db Squeal.ntuples
+ntuples :: Result y -> SquealM db db LibPQ.Row
+ntuples = unsafeSquealIOTxM1 Squeal.ntuples
 
 -- | Analogue of 'Squeal.nfields'.
 --
 -- @since 0.1.0.0
-nfields :: forall db r y. (SquealEnv db r) => Result y -> TxM r LibPQ.Column
-nfields = unsafeSquealIOTxM1 @db Squeal.nfields
+nfields :: Result y -> SquealM db db LibPQ.Column
+nfields = unsafeSquealIOTxM1 Squeal.nfields
 
 -- | Analogue of 'Squeal.resultStatus'.
 --
 -- @since 0.1.0.0
-resultStatus :: forall db r y. (SquealEnv db r) => Result y -> TxM r ExecStatus
-resultStatus = unsafeSquealIOTxM1 @db Squeal.resultStatus
+resultStatus :: Result y -> SquealM db db ExecStatus
+resultStatus = unsafeSquealIOTxM1 Squeal.resultStatus
 
 -- | Analogue of 'Squeal.okResult'.
 --
 -- @since 0.1.0.0
-okResult :: forall db r row. (SquealEnv db r) => K LibPQ.Result row -> TxM r ()
-okResult = unsafeSquealIOTxM1 @db Squeal.okResult
+okResult :: K LibPQ.Result row -> SquealM db db ()
+okResult = unsafeSquealIOTxM1 Squeal.okResult
 
 -- | Analogue of 'Squeal.resultErrorMessage'.
 --
 -- @since 0.1.0.0
-resultErrorMessage :: forall db r y. (SquealEnv db r) => Result y -> TxM r (Maybe ByteString)
-resultErrorMessage = unsafeSquealIOTxM1 @db Squeal.resultErrorMessage
+resultErrorMessage :: Result y -> SquealM db db (Maybe ByteString)
+resultErrorMessage = unsafeSquealIOTxM1 Squeal.resultErrorMessage
 
 -- | Analogue of 'Squeal.resultErrorCode'.
 --
 -- @since 0.1.0.0
-resultErrorCode :: forall db r y. (SquealEnv db r) => Result y -> TxM r (Maybe ByteString)
-resultErrorCode = unsafeSquealIOTxM1 @db Squeal.resultErrorCode
+resultErrorCode :: Result y -> SquealM db db (Maybe ByteString)
+resultErrorCode = unsafeSquealIOTxM1 Squeal.resultErrorCode
 
 -- | Analogue of 'Squeal.executeParams'.
 --
 -- @since 0.1.0.0
-executeParams :: forall db r x y. (SquealEnv db r) => Statement db x y -> x -> TxM r (Result y)
-executeParams = unsafeSquealIOTxM2 @db Squeal.executeParams
+executeParams :: Statement db x y -> x -> SquealM db db (Result y)
+executeParams = unsafeSquealIOTxM2 Squeal.executeParams
 
 -- | Analogue of 'Squeal.executeParams_'.
 --
 -- @since 0.1.0.0
-executeParams_ :: forall db r x. (SquealEnv db r) => Statement db x () -> x -> TxM r ()
-executeParams_ = unsafeSquealIOTxM2 @db Squeal.executeParams_
+executeParams_ :: Statement db x () -> x -> SquealM db db ()
+executeParams_ = unsafeSquealIOTxM2 Squeal.executeParams_
 
 -- | Analogue of 'Squeal.execute'.
 --
 -- @since 0.1.0.0
-execute :: forall db r y. (SquealEnv db r) => Statement db () y -> TxM r (Result y)
-execute = unsafeSquealIOTxM1 @db Squeal.execute
+execute :: Statement db () y -> SquealM db db (Result y)
+execute = unsafeSquealIOTxM1 Squeal.execute
 
 -- | Analogue of 'Squeal.execute_'.
 --
 -- @since 0.1.0.0
-execute_ :: forall db r. (SquealEnv db r) => Statement db () () -> TxM r ()
-execute_ = unsafeSquealIOTxM1 @db Squeal.execute_
+execute_ :: Statement db () () -> SquealM db db ()
+execute_ = unsafeSquealIOTxM1 Squeal.execute_
 
 -- | Analogue of 'Squeal.executePrepared'.
 --
 -- @since 0.1.0.0
 executePrepared
   :: (Traversable list)
-  => Statement db x y -> list x -> SquealM db (list (Result y))
+  => Statement db x y -> list x -> SquealM db db (list (Result y))
 executePrepared = unsafeSquealIOTxM2 Squeal.executePrepared
 
 -- | Analogue of 'Squeal.executePrepared_'.
@@ -121,7 +121,7 @@ executePrepared = unsafeSquealIOTxM2 Squeal.executePrepared
 -- @since 0.1.0.0
 executePrepared_
   :: (Foldable list)
-  => Statement db x () -> list x -> SquealM db ()
+  => Statement db x () -> list x -> SquealM db db ()
 executePrepared_ = unsafeSquealIOTxM2 Squeal.executePrepared_
 
 -- | Analogue of 'Squeal.manipulateParams'.
@@ -133,7 +133,7 @@ manipulateParams
      )
   => Manipulation '[] db params row
   -> x
-  -> SquealM db (Result y)
+  -> SquealM db db (Result y)
 manipulateParams = unsafeSquealIOTxM2 Squeal.manipulateParams
 
 -- | Analogue of 'Squeal.manipulateParams_'.
@@ -141,7 +141,7 @@ manipulateParams = unsafeSquealIOTxM2 Squeal.manipulateParams
 -- @since 0.1.0.0
 manipulateParams_
   :: (GenericParams db params x xs)
-  => Manipulation '[] db params '[] -> x -> SquealM db ()
+  => Manipulation '[] db params '[] -> x -> SquealM db db ()
 manipulateParams_ = unsafeSquealIOTxM2 Squeal.manipulateParams_
 
 -- | Analogue of 'Squeal.manipulate'.
@@ -149,14 +149,14 @@ manipulateParams_ = unsafeSquealIOTxM2 Squeal.manipulateParams_
 -- @since 0.1.0.0
 manipulate
   :: (Squeal.GenericRow row y ys)
-  => Manipulation '[] db '[] row -> SquealM db (Result y)
+  => Manipulation '[] db '[] row -> SquealM db db (Result y)
 manipulate = unsafeSquealIOTxM1 Squeal.manipulate
 
 -- | Analogue of 'Squeal.manipulate_'.
 --
 -- @since 0.1.0.0
 manipulate_
-  :: Manipulation '[] db '[] '[] -> SquealM db ()
+  :: Manipulation '[] db '[] '[] -> SquealM db db ()
 manipulate_ = unsafeSquealIOTxM1 Squeal.manipulate_
 
 -- | Analogue of 'Squeal.runQueryParams'.
@@ -167,7 +167,7 @@ runQueryParams
      , SOP.IsRecord y ys
      , SOP.AllZip Squeal.FromField row ys
      )
-  => Squeal.Query '[] '[] db params row -> x -> SquealM db (Result y)
+  => Squeal.Query '[] '[] db params row -> x -> SquealM db db (Result y)
 runQueryParams = unsafeSquealIOTxM2 Squeal.runQueryParams
 
 -- | Analogue of 'Squeal.runQuery'.
@@ -177,7 +177,7 @@ runQuery
   :: ( SOP.IsRecord y ys
      , SOP.AllZip Squeal.FromField row ys
      )
-  => Squeal.Query '[] '[] db '[] row -> SquealM db (Result y)
+  => Squeal.Query '[] '[] db '[] row -> SquealM db db (Result y)
 runQuery = unsafeSquealIOTxM1 Squeal.runQuery
 
 -- | Analogue of 'Squeal.traversePrepared'.
@@ -191,7 +191,7 @@ traversePrepared
      )
   => Manipulation '[] db params row
   -> list x
-  -> SquealM db (list (Result y))
+  -> SquealM db db (list (Result y))
 traversePrepared = unsafeSquealIOTxM2 Squeal.traversePrepared
 
 -- | Analogue of 'Squeal.forPrepared'.
@@ -205,7 +205,7 @@ forPrepared
      )
   => list x
   -> Manipulation '[] db params row
-  -> SquealM db (list (Result y))
+  -> SquealM db db (list (Result y))
 forPrepared = unsafeSquealIOTxM2 Squeal.forPrepared
 
 -- | Analogue of 'Squeal.traversePrepared_'.
@@ -217,7 +217,7 @@ traversePrepared_
      )
   => Manipulation '[] db params '[]
   -> list x
-  -> SquealM db ()
+  -> SquealM db db ()
 traversePrepared_ = unsafeSquealIOTxM2 Squeal.traversePrepared_
 
 -- | Analogue of 'Squeal.forPrepared_'.
@@ -229,35 +229,35 @@ forPrepared_
      )
   => list x
   -> Manipulation '[] db params '[]
-  -> SquealM db ()
+  -> SquealM db db ()
 forPrepared_ = unsafeSquealIOTxM2 Squeal.forPrepared_
 
 -- | Analogue of 'Squeal.transactionally'.
 --
 -- @since 0.1.0.0
-transactionally :: forall db r a. (SquealEnv db r) => TransactionMode -> r -> TxM r a -> IO a
-transactionally m = unsafeRunSquealTransaction @db (Squeal.transactionally @_ @db m)
+transactionally :: (SquealEnv r) => TransactionMode -> r -> TxM r a -> IO a
+transactionally m = unsafeRunSquealTransaction (Squeal.transactionally m)
 
 -- | Analogue of 'Squeal.transactionally_'.
 --
 -- @since 0.1.0.0
-transactionally_ :: forall db r a. (SquealEnv db r) => r -> TxM r a -> IO a
-transactionally_ = unsafeRunSquealTransaction @db Squeal.transactionally_
+transactionally_ :: (SquealEnv r) => r -> TxM r a -> IO a
+transactionally_ = unsafeRunSquealTransaction Squeal.transactionally_
 
 -- | Analogue of 'Squeal.transactionallyRetry'.
 --
 -- @since 0.1.0.0
-transactionallyRetry :: forall db r a. (SquealEnv db r) => TransactionMode -> r -> TxM r a -> IO a
-transactionallyRetry m = unsafeRunSquealTransaction @db (Squeal.transactionallyRetry m)
+transactionallyRetry :: (SquealEnv r) => TransactionMode -> r -> TxM r a -> IO a
+transactionallyRetry m = unsafeRunSquealTransaction (Squeal.transactionallyRetry m)
 
 -- | Analogue of 'Squeal.ephemerally'.
 --
 -- @since 0.1.0.0
-ephemerally :: forall db r a. (SquealEnv db r) => TransactionMode -> r -> TxM r a -> IO a
-ephemerally m = unsafeRunSquealTransaction @db (Squeal.ephemerally m)
+ephemerally :: (SquealEnv r) => TransactionMode -> r -> TxM r a -> IO a
+ephemerally m = unsafeRunSquealTransaction (Squeal.ephemerally m)
 
 -- | Analogue of 'Squeal.ephemerally_'.
 --
 -- @since 0.1.0.0
-ephemerally_ :: forall db r a. (SquealEnv db r) => r -> TxM r a -> IO a
-ephemerally_ = unsafeRunSquealTransaction @db Squeal.ephemerally_
+ephemerally_ :: (SquealEnv r) => r -> TxM r a -> IO a
+ephemerally_ = unsafeRunSquealTransaction Squeal.ephemerally_

--- a/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
@@ -245,11 +245,12 @@ transactionally m = unsafeRunSquealTransaction (Squeal.transactionally m)
 transactionally_ :: (SquealEnv r) => r -> TxM r a -> IO a
 transactionally_ = unsafeRunSquealTransaction Squeal.transactionally_
 
--- | Analogue of 'Squeal.transactionallyRetry'.
---
--- @since 0.1.0.0
-transactionallyRetry :: (SquealEnv r) => TransactionMode -> r -> TxM r a -> IO a
-transactionallyRetry m = unsafeRunSquealTransaction (Squeal.transactionallyRetry m)
+-- TODO: Removed for now until we provide a retry mechanism.
+-- -- | Analogue of 'Squeal.transactionallyRetry'.
+-- --
+-- -- @since 0.1.0.0
+-- transactionallyRetry :: (SquealEnv r) => TransactionMode -> r -> TxM r a -> IO a
+-- transactionallyRetry m = unsafeRunSquealTransaction (Squeal.transactionallyRetry m)
 
 -- | Analogue of 'Squeal.ephemerally'.
 --

--- a/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
@@ -9,6 +9,7 @@ module Database.PostgreSQL.Tx.Squeal
   ( SquealEnv
   , SquealM
   , SquealTxM(SquealTxM, fromSquealTxM)
+  , DefaultSquealTxM
   , SquealConnection
   , mkSquealConnection
   , module Database.PostgreSQL.Tx.Squeal
@@ -27,85 +28,85 @@ import qualified Squeal.PostgreSQL as Squeal
 -- | Analogue of 'Squeal.getRow'.
 --
 -- @since 0.1.0.0
-getRow :: LibPQ.Row -> Result y -> SquealM db db y
+getRow :: LibPQ.Row -> Result y -> DefaultSquealTxM db y
 getRow = unsafeSquealIOTxM2 Squeal.getRow
 
 -- | Analogue of 'Squeal.firstRow'.
 --
 -- @since 0.1.0.0
-firstRow :: Result y -> SquealM db db (Maybe y)
+firstRow :: Result y -> DefaultSquealTxM db (Maybe y)
 firstRow = unsafeSquealIOTxM1 Squeal.firstRow
 
 -- | Analogue of 'Squeal.getRows'.
 --
 -- @since 0.1.0.0
-getRows :: Result y -> SquealM db db [y]
+getRows :: Result y -> DefaultSquealTxM db [y]
 getRows = unsafeSquealIOTxM1 Squeal.getRows
 
 -- | Analogue of 'Squeal.nextRow'.
 --
 -- @since 0.1.0.0
-nextRow :: LibPQ.Row -> Result y -> LibPQ.Row -> SquealM db db (Maybe (LibPQ.Row, y))
+nextRow :: LibPQ.Row -> Result y -> LibPQ.Row -> DefaultSquealTxM db (Maybe (LibPQ.Row, y))
 nextRow = unsafeSquealIOTxM3 Squeal.nextRow
 
 -- | Analogue of 'Squeal.ntuples'.
 --
 -- @since 0.1.0.0
-ntuples :: Result y -> SquealM db db LibPQ.Row
+ntuples :: Result y -> DefaultSquealTxM db LibPQ.Row
 ntuples = unsafeSquealIOTxM1 Squeal.ntuples
 
 -- | Analogue of 'Squeal.nfields'.
 --
 -- @since 0.1.0.0
-nfields :: Result y -> SquealM db db LibPQ.Column
+nfields :: Result y -> DefaultSquealTxM db LibPQ.Column
 nfields = unsafeSquealIOTxM1 Squeal.nfields
 
 -- | Analogue of 'Squeal.resultStatus'.
 --
 -- @since 0.1.0.0
-resultStatus :: Result y -> SquealM db db ExecStatus
+resultStatus :: Result y -> DefaultSquealTxM db ExecStatus
 resultStatus = unsafeSquealIOTxM1 Squeal.resultStatus
 
 -- | Analogue of 'Squeal.okResult'.
 --
 -- @since 0.1.0.0
-okResult :: K LibPQ.Result row -> SquealM db db ()
+okResult :: K LibPQ.Result row -> DefaultSquealTxM db ()
 okResult = unsafeSquealIOTxM1 Squeal.okResult
 
 -- | Analogue of 'Squeal.resultErrorMessage'.
 --
 -- @since 0.1.0.0
-resultErrorMessage :: Result y -> SquealM db db (Maybe ByteString)
+resultErrorMessage :: Result y -> DefaultSquealTxM db (Maybe ByteString)
 resultErrorMessage = unsafeSquealIOTxM1 Squeal.resultErrorMessage
 
 -- | Analogue of 'Squeal.resultErrorCode'.
 --
 -- @since 0.1.0.0
-resultErrorCode :: Result y -> SquealM db db (Maybe ByteString)
+resultErrorCode :: Result y -> DefaultSquealTxM db (Maybe ByteString)
 resultErrorCode = unsafeSquealIOTxM1 Squeal.resultErrorCode
 
 -- | Analogue of 'Squeal.executeParams'.
 --
 -- @since 0.1.0.0
-executeParams :: Statement db x y -> x -> SquealM db db (Result y)
+executeParams :: Statement db x y -> x -> DefaultSquealTxM db (Result y)
 executeParams = unsafeSquealIOTxM2 Squeal.executeParams
 
 -- | Analogue of 'Squeal.executeParams_'.
 --
 -- @since 0.1.0.0
-executeParams_ :: Statement db x () -> x -> SquealM db db ()
+executeParams_ :: Statement db x () -> x -> DefaultSquealTxM db ()
 executeParams_ = unsafeSquealIOTxM2 Squeal.executeParams_
 
 -- | Analogue of 'Squeal.execute'.
 --
 -- @since 0.1.0.0
-execute :: Statement db () y -> SquealM db db (Result y)
+execute :: Statement db () y -> DefaultSquealTxM db (Result y)
 execute = unsafeSquealIOTxM1 Squeal.execute
 
 -- | Analogue of 'Squeal.execute_'.
 --
 -- @since 0.1.0.0
-execute_ :: Statement db () () -> SquealM db db ()
+execute_ :: Statement db () () -> DefaultSquealTxM db ()
 execute_ = unsafeSquealIOTxM1 Squeal.execute_
 
 -- | Analogue of 'Squeal.executePrepared'.
@@ -113,7 +114,7 @@ execute_ = unsafeSquealIOTxM1 Squeal.execute_
 -- @since 0.1.0.0
 executePrepared
   :: (Traversable list)
-  => Statement db x y -> list x -> SquealM db db (list (Result y))
+  => Statement db x y -> list x -> DefaultSquealTxM db (list (Result y))
 executePrepared = unsafeSquealIOTxM2 Squeal.executePrepared
 
 -- | Analogue of 'Squeal.executePrepared_'.
@@ -121,7 +122,7 @@ executePrepared = unsafeSquealIOTxM2 Squeal.executePrepared
 -- @since 0.1.0.0
 executePrepared_
   :: (Foldable list)
-  => Statement db x () -> list x -> SquealM db db ()
+  => Statement db x () -> list x -> DefaultSquealTxM db ()
 executePrepared_ = unsafeSquealIOTxM2 Squeal.executePrepared_
 
 -- | Analogue of 'Squeal.manipulateParams'.
@@ -133,7 +134,7 @@ manipulateParams
      )
   => Manipulation '[] db params row
   -> x
-  -> SquealM db db (Result y)
+  -> DefaultSquealTxM db (Result y)
 manipulateParams = unsafeSquealIOTxM2 Squeal.manipulateParams
 
 -- | Analogue of 'Squeal.manipulateParams_'.
@@ -141,7 +142,7 @@ manipulateParams = unsafeSquealIOTxM2 Squeal.manipulateParams
 -- @since 0.1.0.0
 manipulateParams_
   :: (GenericParams db params x xs)
-  => Manipulation '[] db params '[] -> x -> SquealM db db ()
+  => Manipulation '[] db params '[] -> x -> DefaultSquealTxM db ()
 manipulateParams_ = unsafeSquealIOTxM2 Squeal.manipulateParams_
 
 -- | Analogue of 'Squeal.manipulate'.
@@ -149,14 +150,14 @@ manipulateParams_ = unsafeSquealIOTxM2 Squeal.manipulateParams_
 -- @since 0.1.0.0
 manipulate
   :: (Squeal.GenericRow row y ys)
-  => Manipulation '[] db '[] row -> SquealM db db (Result y)
+  => Manipulation '[] db '[] row -> DefaultSquealTxM db (Result y)
 manipulate = unsafeSquealIOTxM1 Squeal.manipulate
 
 -- | Analogue of 'Squeal.manipulate_'.
 --
 -- @since 0.1.0.0
 manipulate_
-  :: Manipulation '[] db '[] '[] -> SquealM db db ()
+  :: Manipulation '[] db '[] '[] -> DefaultSquealTxM db ()
 manipulate_ = unsafeSquealIOTxM1 Squeal.manipulate_
 
 -- | Analogue of 'Squeal.runQueryParams'.
@@ -167,7 +168,7 @@ runQueryParams
      , SOP.IsRecord y ys
      , SOP.AllZip Squeal.FromField row ys
      )
-  => Squeal.Query '[] '[] db params row -> x -> SquealM db db (Result y)
+  => Squeal.Query '[] '[] db params row -> x -> DefaultSquealTxM db (Result y)
 runQueryParams = unsafeSquealIOTxM2 Squeal.runQueryParams
 
 -- | Analogue of 'Squeal.runQuery'.
@@ -177,7 +178,7 @@ runQuery
   :: ( SOP.IsRecord y ys
      , SOP.AllZip Squeal.FromField row ys
      )
-  => Squeal.Query '[] '[] db '[] row -> SquealM db db (Result y)
+  => Squeal.Query '[] '[] db '[] row -> DefaultSquealTxM db (Result y)
 runQuery = unsafeSquealIOTxM1 Squeal.runQuery
 
 -- | Analogue of 'Squeal.traversePrepared'.
@@ -191,7 +192,7 @@ traversePrepared
      )
   => Manipulation '[] db params row
   -> list x
-  -> SquealM db db (list (Result y))
+  -> DefaultSquealTxM db (list (Result y))
 traversePrepared = unsafeSquealIOTxM2 Squeal.traversePrepared
 
 -- | Analogue of 'Squeal.forPrepared'.
@@ -205,7 +206,7 @@ forPrepared
      )
   => list x
   -> Manipulation '[] db params row
-  -> SquealM db db (list (Result y))
+  -> DefaultSquealTxM db (list (Result y))
 forPrepared = unsafeSquealIOTxM2 Squeal.forPrepared
 
 -- | Analogue of 'Squeal.traversePrepared_'.
@@ -217,7 +218,7 @@ traversePrepared_
      )
   => Manipulation '[] db params '[]
   -> list x
-  -> SquealM db db ()
+  -> DefaultSquealTxM db ()
 traversePrepared_ = unsafeSquealIOTxM2 Squeal.traversePrepared_
 
 -- | Analogue of 'Squeal.forPrepared_'.
@@ -229,7 +230,7 @@ forPrepared_
      )
   => list x
   -> Manipulation '[] db params '[]
-  -> SquealM db db ()
+  -> DefaultSquealTxM db ()
 forPrepared_ = unsafeSquealIOTxM2 Squeal.forPrepared_
 
 -- | Analogue of 'Squeal.transactionally'.

--- a/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal.hs
@@ -8,8 +8,8 @@
 module Database.PostgreSQL.Tx.Squeal
   ( SquealEnv
   , SquealM
-  , SquealTxM(SquealTxM, fromSquealTxM)
-  , DefaultSquealTxM
+  , SquealTxM'(SquealTxM, fromSquealTxM)
+  , SquealTxM
   , SquealConnection
   , mkSquealConnection
   , module Database.PostgreSQL.Tx.Squeal
@@ -28,85 +28,85 @@ import qualified Squeal.PostgreSQL as Squeal
 -- | Analogue of 'Squeal.getRow'.
 --
 -- @since 0.1.0.0
-getRow :: LibPQ.Row -> Result y -> DefaultSquealTxM db y
+getRow :: LibPQ.Row -> Result y -> SquealTxM db y
 getRow = unsafeSquealIOTxM2 Squeal.getRow
 
 -- | Analogue of 'Squeal.firstRow'.
 --
 -- @since 0.1.0.0
-firstRow :: Result y -> DefaultSquealTxM db (Maybe y)
+firstRow :: Result y -> SquealTxM db (Maybe y)
 firstRow = unsafeSquealIOTxM1 Squeal.firstRow
 
 -- | Analogue of 'Squeal.getRows'.
 --
 -- @since 0.1.0.0
-getRows :: Result y -> DefaultSquealTxM db [y]
+getRows :: Result y -> SquealTxM db [y]
 getRows = unsafeSquealIOTxM1 Squeal.getRows
 
 -- | Analogue of 'Squeal.nextRow'.
 --
 -- @since 0.1.0.0
-nextRow :: LibPQ.Row -> Result y -> LibPQ.Row -> DefaultSquealTxM db (Maybe (LibPQ.Row, y))
+nextRow :: LibPQ.Row -> Result y -> LibPQ.Row -> SquealTxM db (Maybe (LibPQ.Row, y))
 nextRow = unsafeSquealIOTxM3 Squeal.nextRow
 
 -- | Analogue of 'Squeal.ntuples'.
 --
 -- @since 0.1.0.0
-ntuples :: Result y -> DefaultSquealTxM db LibPQ.Row
+ntuples :: Result y -> SquealTxM db LibPQ.Row
 ntuples = unsafeSquealIOTxM1 Squeal.ntuples
 
 -- | Analogue of 'Squeal.nfields'.
 --
 -- @since 0.1.0.0
-nfields :: Result y -> DefaultSquealTxM db LibPQ.Column
+nfields :: Result y -> SquealTxM db LibPQ.Column
 nfields = unsafeSquealIOTxM1 Squeal.nfields
 
 -- | Analogue of 'Squeal.resultStatus'.
 --
 -- @since 0.1.0.0
-resultStatus :: Result y -> DefaultSquealTxM db ExecStatus
+resultStatus :: Result y -> SquealTxM db ExecStatus
 resultStatus = unsafeSquealIOTxM1 Squeal.resultStatus
 
 -- | Analogue of 'Squeal.okResult'.
 --
 -- @since 0.1.0.0
-okResult :: K LibPQ.Result row -> DefaultSquealTxM db ()
+okResult :: K LibPQ.Result row -> SquealTxM db ()
 okResult = unsafeSquealIOTxM1 Squeal.okResult
 
 -- | Analogue of 'Squeal.resultErrorMessage'.
 --
 -- @since 0.1.0.0
-resultErrorMessage :: Result y -> DefaultSquealTxM db (Maybe ByteString)
+resultErrorMessage :: Result y -> SquealTxM db (Maybe ByteString)
 resultErrorMessage = unsafeSquealIOTxM1 Squeal.resultErrorMessage
 
 -- | Analogue of 'Squeal.resultErrorCode'.
 --
 -- @since 0.1.0.0
-resultErrorCode :: Result y -> DefaultSquealTxM db (Maybe ByteString)
+resultErrorCode :: Result y -> SquealTxM db (Maybe ByteString)
 resultErrorCode = unsafeSquealIOTxM1 Squeal.resultErrorCode
 
 -- | Analogue of 'Squeal.executeParams'.
 --
 -- @since 0.1.0.0
-executeParams :: Statement db x y -> x -> DefaultSquealTxM db (Result y)
+executeParams :: Statement db x y -> x -> SquealTxM db (Result y)
 executeParams = unsafeSquealIOTxM2 Squeal.executeParams
 
 -- | Analogue of 'Squeal.executeParams_'.
 --
 -- @since 0.1.0.0
-executeParams_ :: Statement db x () -> x -> DefaultSquealTxM db ()
+executeParams_ :: Statement db x () -> x -> SquealTxM db ()
 executeParams_ = unsafeSquealIOTxM2 Squeal.executeParams_
 
 -- | Analogue of 'Squeal.execute'.
 --
 -- @since 0.1.0.0
-execute :: Statement db () y -> DefaultSquealTxM db (Result y)
+execute :: Statement db () y -> SquealTxM db (Result y)
 execute = unsafeSquealIOTxM1 Squeal.execute
 
 -- | Analogue of 'Squeal.execute_'.
 --
 -- @since 0.1.0.0
-execute_ :: Statement db () () -> DefaultSquealTxM db ()
+execute_ :: Statement db () () -> SquealTxM db ()
 execute_ = unsafeSquealIOTxM1 Squeal.execute_
 
 -- | Analogue of 'Squeal.executePrepared'.
@@ -114,7 +114,7 @@ execute_ = unsafeSquealIOTxM1 Squeal.execute_
 -- @since 0.1.0.0
 executePrepared
   :: (Traversable list)
-  => Statement db x y -> list x -> DefaultSquealTxM db (list (Result y))
+  => Statement db x y -> list x -> SquealTxM db (list (Result y))
 executePrepared = unsafeSquealIOTxM2 Squeal.executePrepared
 
 -- | Analogue of 'Squeal.executePrepared_'.
@@ -122,7 +122,7 @@ executePrepared = unsafeSquealIOTxM2 Squeal.executePrepared
 -- @since 0.1.0.0
 executePrepared_
   :: (Foldable list)
-  => Statement db x () -> list x -> DefaultSquealTxM db ()
+  => Statement db x () -> list x -> SquealTxM db ()
 executePrepared_ = unsafeSquealIOTxM2 Squeal.executePrepared_
 
 -- | Analogue of 'Squeal.manipulateParams'.
@@ -134,7 +134,7 @@ manipulateParams
      )
   => Manipulation '[] db params row
   -> x
-  -> DefaultSquealTxM db (Result y)
+  -> SquealTxM db (Result y)
 manipulateParams = unsafeSquealIOTxM2 Squeal.manipulateParams
 
 -- | Analogue of 'Squeal.manipulateParams_'.
@@ -142,7 +142,7 @@ manipulateParams = unsafeSquealIOTxM2 Squeal.manipulateParams
 -- @since 0.1.0.0
 manipulateParams_
   :: (GenericParams db params x xs)
-  => Manipulation '[] db params '[] -> x -> DefaultSquealTxM db ()
+  => Manipulation '[] db params '[] -> x -> SquealTxM db ()
 manipulateParams_ = unsafeSquealIOTxM2 Squeal.manipulateParams_
 
 -- | Analogue of 'Squeal.manipulate'.
@@ -150,14 +150,14 @@ manipulateParams_ = unsafeSquealIOTxM2 Squeal.manipulateParams_
 -- @since 0.1.0.0
 manipulate
   :: (Squeal.GenericRow row y ys)
-  => Manipulation '[] db '[] row -> DefaultSquealTxM db (Result y)
+  => Manipulation '[] db '[] row -> SquealTxM db (Result y)
 manipulate = unsafeSquealIOTxM1 Squeal.manipulate
 
 -- | Analogue of 'Squeal.manipulate_'.
 --
 -- @since 0.1.0.0
 manipulate_
-  :: Manipulation '[] db '[] '[] -> DefaultSquealTxM db ()
+  :: Manipulation '[] db '[] '[] -> SquealTxM db ()
 manipulate_ = unsafeSquealIOTxM1 Squeal.manipulate_
 
 -- | Analogue of 'Squeal.runQueryParams'.
@@ -168,7 +168,7 @@ runQueryParams
      , SOP.IsRecord y ys
      , SOP.AllZip Squeal.FromField row ys
      )
-  => Squeal.Query '[] '[] db params row -> x -> DefaultSquealTxM db (Result y)
+  => Squeal.Query '[] '[] db params row -> x -> SquealTxM db (Result y)
 runQueryParams = unsafeSquealIOTxM2 Squeal.runQueryParams
 
 -- | Analogue of 'Squeal.runQuery'.
@@ -178,7 +178,7 @@ runQuery
   :: ( SOP.IsRecord y ys
      , SOP.AllZip Squeal.FromField row ys
      )
-  => Squeal.Query '[] '[] db '[] row -> DefaultSquealTxM db (Result y)
+  => Squeal.Query '[] '[] db '[] row -> SquealTxM db (Result y)
 runQuery = unsafeSquealIOTxM1 Squeal.runQuery
 
 -- | Analogue of 'Squeal.traversePrepared'.
@@ -192,7 +192,7 @@ traversePrepared
      )
   => Manipulation '[] db params row
   -> list x
-  -> DefaultSquealTxM db (list (Result y))
+  -> SquealTxM db (list (Result y))
 traversePrepared = unsafeSquealIOTxM2 Squeal.traversePrepared
 
 -- | Analogue of 'Squeal.forPrepared'.
@@ -206,7 +206,7 @@ forPrepared
      )
   => list x
   -> Manipulation '[] db params row
-  -> DefaultSquealTxM db (list (Result y))
+  -> SquealTxM db (list (Result y))
 forPrepared = unsafeSquealIOTxM2 Squeal.forPrepared
 
 -- | Analogue of 'Squeal.traversePrepared_'.
@@ -218,7 +218,7 @@ traversePrepared_
      )
   => Manipulation '[] db params '[]
   -> list x
-  -> DefaultSquealTxM db ()
+  -> SquealTxM db ()
 traversePrepared_ = unsafeSquealIOTxM2 Squeal.traversePrepared_
 
 -- | Analogue of 'Squeal.forPrepared_'.
@@ -230,7 +230,7 @@ forPrepared_
      )
   => list x
   -> Manipulation '[] db params '[]
-  -> DefaultSquealTxM db ()
+  -> SquealTxM db ()
 forPrepared_ = unsafeSquealIOTxM2 Squeal.forPrepared_
 
 -- | Analogue of 'Squeal.transactionally'.

--- a/squeal/src/Database/PostgreSQL/Tx/Squeal/Internal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal/Internal.hs
@@ -32,11 +32,17 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 type SquealEnv r =
   (TxEnv SquealConnection r) :: Constraint
 
--- | Monad type alias for running @squeal-postgresql@ via @postgresql-tx@
--- which includes the 'SquealEnv' constraint. See 'SquealTxM'.
+-- | Monad type alias for running @squeal-postgresql@ via @postgresql-tx@.
 --
 -- @since 0.2.0.0
-type SquealM db0 db1 a = forall r. (SquealEnv r) => SquealTxM db0 db1 r a
+type SquealM a = forall r. (SquealEnv r) => TxM r a
+
+-- | Alias for 'SquealTxM' but has the 'SquealEnv' constraint applied to @r@
+-- and uses @db@ for both @db0@ and @db1@ since this is the common case.
+--
+-- @since 0.2.0.0
+type DefaultSquealTxM (db :: SchemasType) a =
+  forall r. (SquealEnv r) => SquealTxM db db r a
 
 -- | A newtype wrapper around 'TxM' which includes the @squeal@ 'SchemasType'
 -- parameters @db0@ and @db1@. These are used only as type information.
@@ -86,8 +92,9 @@ mkSquealConnection :: LibPQ.Connection -> SquealConnection
 mkSquealConnection conn = UnsafeSquealConnection (pure conn)
 
 unsafeSquealIOTxM
-  :: PQ db db IO a
-  -> SquealM db db a
+  :: (SquealEnv r)
+  => PQ db db IO a
+  -> SquealTxM db db r a
 unsafeSquealIOTxM (PQ f) = SquealTxM do
   UnsafeSquealConnection { unsafeGetLibPQConnection } <- askTxEnv
   unsafeRunIOInTxM do
@@ -96,18 +103,21 @@ unsafeSquealIOTxM (PQ f) = SquealTxM do
     pure a
 
 unsafeSquealIOTxM1
-  :: (x1 -> PQ db db IO a)
-  -> x1 -> SquealM db db a
+  :: (SquealEnv r)
+  => (x1 -> PQ db db IO a)
+  -> x1 -> SquealTxM db db r a
 unsafeSquealIOTxM1 f x1 = unsafeSquealIOTxM $ f x1
 
 unsafeSquealIOTxM2
-  :: (x1 -> x2 -> PQ db db IO a)
-  -> x1 -> x2 -> SquealM db db a
+  :: (SquealEnv r)
+  => (x1 -> x2 -> PQ db db IO a)
+  -> x1 -> x2 -> SquealTxM db db r a
 unsafeSquealIOTxM2 f x1 x2 = unsafeSquealIOTxM $ f x1 x2
 
 unsafeSquealIOTxM3
-  :: (x1 -> x2 -> x3 -> PQ db db IO a)
-  -> x1 -> x2 -> x3 -> SquealM db db a
+  :: (SquealEnv r)
+  => (x1 -> x2 -> x3 -> PQ db db IO a)
+  -> x1 -> x2 -> x3 -> SquealTxM db db r a
 unsafeSquealIOTxM3 f x1 x2 x3 = unsafeSquealIOTxM $ f x1 x2 x3
 
 unsafeRunSquealTransaction

--- a/squeal/src/Database/PostgreSQL/Tx/Squeal/Internal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal/Internal.hs
@@ -37,22 +37,22 @@ type SquealEnv r =
 -- @since 0.2.0.0
 type SquealM a = forall r. (SquealEnv r) => TxM r a
 
--- | Alias for 'SquealTxM'' but has the 'SquealEnv' constraint applied to @r@
--- and uses @db@ for both @db0@ and @db1@ since this is the common case.
+-- | Alias for 'SquealTxM'' but has the 'SquealEnv' constraint applied to @r@.
 --
 -- @since 0.2.0.0
 type SquealTxM (db :: SchemasType) a =
-  forall r. (SquealEnv r) => SquealTxM' db db r a
+  forall r. (SquealEnv r) => SquealTxM' db r a
 
 -- | A newtype wrapper around 'TxM' which includes the @squeal@ 'SchemasType'
--- parameters @db0@ and @db1@. These are used only as type information.
+-- parameter @db@. This is used only as type information.
 -- You can easily convert 'TxM' to and from 'SquealTxM'' by using the
 -- 'SquealTxM'' constructor and 'fromSquealTxM' function, respectively.
 --
--- In practice, you will likely prefer to use the 'SquealTxM' type alias.
+-- In practice, you will likely prefer to use the 'SquealTxM' type alias
+-- as it includes the 'SquealEnv' constraint on @r@.
 --
 -- @since 0.2.0.0
-newtype SquealTxM' (db0 :: SchemasType) (db1 :: SchemasType) r a =
+newtype SquealTxM' (db :: SchemasType) r a =
   SquealTxM
     { -- | Convert a 'SquealTxM'' to a 'TxM'.
       --
@@ -72,7 +72,7 @@ newtype SquealTxM' (db0 :: SchemasType) (db1 :: SchemasType) r a =
 instance
   ( TypeError
       ('Text "MonadIO is banned in SquealTxM'; use 'SquealTxM . unsafeRunIOInTxM' if you are sure this is safe IO")
-  ) => MonadIO (SquealTxM' db0 db1 r)
+  ) => MonadIO (SquealTxM' db r)
   where
   liftIO = undefined
 

--- a/squeal/src/Database/PostgreSQL/Tx/Squeal/Internal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal/Internal.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Database.PostgreSQL.Tx.Squeal.Internal
   ( -- * Disclaimer
     -- $disclaimer
@@ -15,29 +18,55 @@ module Database.PostgreSQL.Tx.Squeal.Internal
     module Database.PostgreSQL.Tx.Squeal.Internal
   ) where
 
+import Control.Monad.IO.Class (MonadIO(liftIO))
 import Data.Kind (Constraint)
-import Database.PostgreSQL.Tx (TxEnvs, TxM, askTxEnv)
+import Database.PostgreSQL.Tx (TxEnv, TxM, askTxEnv)
 import Database.PostgreSQL.Tx.Squeal.Internal.Reexport
-import Database.PostgreSQL.Tx.Unsafe (unsafeRunIOInTxM, unsafeRunTxM, unsafeLookupTxEnvIO)
+import Database.PostgreSQL.Tx.Unsafe (unsafeLookupTxEnvIO, unsafeRunIOInTxM, unsafeRunTxM)
+import GHC.TypeLits (ErrorMessage(Text), TypeError)
 import qualified Database.PostgreSQL.LibPQ as LibPQ
-import qualified Squeal.PostgreSQL as Squeal
 
 -- | Runtime environment needed to run @squeal-postgresql@ via @postgresql-tx@.
 --
 -- @since 0.2.0.0
-type SquealEnv (db :: Squeal.SchemasType) r =
-  (TxEnvs '[SquealSchemas db, SquealConnection] r) :: Constraint
+type SquealEnv r =
+  (TxEnv SquealConnection r) :: Constraint
 
--- | Monad type alias for running @squeal-postgresql@ via @postgresql-tx@.
+-- | Monad type alias for running @squeal-postgresql@ via @postgresql-tx@
+-- which includes the 'SquealEnv' constraint. See 'SquealTxM'.
 --
 -- @since 0.2.0.0
-type SquealM db a = forall r. (SquealEnv db r) => TxM r a
+type SquealM db0 db1 a = forall r. (SquealEnv r) => SquealTxM db0 db1 r a
 
--- | Used in the 'SquealEnv' to specify the applicable schemas in which
--- a 'TxM' can be run.
+-- | A newtype wrapper around 'TxM' which includes the @squeal@ 'SchemasType'
+-- parameters @db0@ and @db1@. These are used only as type information.
+-- You can easily convert 'TxM' to and from 'SquealTxM' by using the
+-- 'SquealTxM' constructor and 'fromSquealTxM' function, respectively.
 --
 -- @since 0.2.0.0
-data SquealSchemas (db :: Squeal.SchemasType) = SquealSchemas
+newtype SquealTxM (db0 :: SchemasType) (db1 :: SchemasType) r a =
+  SquealTxM
+    { -- | Convert a 'SquealTxM' to a 'TxM'.
+      --
+      -- @since 0.2.0.0
+      fromSquealTxM :: TxM r a
+    }
+  deriving newtype (Functor, Applicative, Monad)
+
+-- | The 'SquealTxM' monad discourages performing arbitrary 'IO' within a
+-- transaction, so this instance generates a type error when client code tries
+-- to call 'liftIO'.
+--
+-- Note that specialize this instance for 'SquealTxM' rather than derive it
+-- via newtype so we can provide a better error message.
+--
+-- @since 0.2.0.0
+instance
+  ( TypeError
+      ('Text "MonadIO is banned in SquealTxM; use 'SquealTxM . unsafeRunIOInTxM' if you are sure this is safe IO")
+  ) => MonadIO (SquealTxM db0 db1 r)
+  where
+  liftIO = undefined
 
 -- | Used in the 'SquealEnv' to specify the 'LibPQ.Connection' to use.
 -- Should produce the same 'LibPQ.Connection' if called multiple times
@@ -47,54 +76,52 @@ data SquealSchemas (db :: Squeal.SchemasType) = SquealSchemas
 -- @since 0.2.0.0
 newtype SquealConnection =
   UnsafeSquealConnection
-    { unsafeWithLibPQConnection :: forall a. (LibPQ.Connection -> IO a) -> IO a
+    { unsafeGetLibPQConnection :: IO LibPQ.Connection
     }
 
 -- | Construct a 'SquealConnection' from a 'LibPQ.Connection'.
 --
 -- @since 0.2.0.0
 mkSquealConnection :: LibPQ.Connection -> SquealConnection
-mkSquealConnection conn = UnsafeSquealConnection ($ conn)
+mkSquealConnection conn = UnsafeSquealConnection (pure conn)
 
 unsafeSquealIOTxM
-  :: forall db r a. (SquealEnv db r)
-  => PQ db db IO a -> TxM r a
-unsafeSquealIOTxM (Squeal.PQ f) = do
-  UnsafeSquealConnection { unsafeWithLibPQConnection } <- askTxEnv
-  unsafeRunIOInTxM $ unsafeWithLibPQConnection \conn -> do
-    Squeal.K a <- f (Squeal.K conn)
+  :: PQ db db IO a
+  -> SquealM db db a
+unsafeSquealIOTxM (PQ f) = SquealTxM do
+  UnsafeSquealConnection { unsafeGetLibPQConnection } <- askTxEnv
+  unsafeRunIOInTxM do
+    conn <- unsafeGetLibPQConnection
+    K a <- f (K conn)
     pure a
 
 unsafeSquealIOTxM1
-  :: forall db r x1 a. (SquealEnv db r)
-  => (x1 -> PQ db db IO a)
-  -> x1 -> TxM r a
+  :: (x1 -> PQ db db IO a)
+  -> x1 -> SquealM db db a
 unsafeSquealIOTxM1 f x1 = unsafeSquealIOTxM $ f x1
 
 unsafeSquealIOTxM2
-  :: forall db r x1 x2 a. (SquealEnv db r)
-  => (x1 -> x2 -> PQ db db IO a)
-  -> x1 -> x2 -> TxM r a
+  :: (x1 -> x2 -> PQ db db IO a)
+  -> x1 -> x2 -> SquealM db db a
 unsafeSquealIOTxM2 f x1 x2 = unsafeSquealIOTxM $ f x1 x2
 
 unsafeSquealIOTxM3
-  :: forall db r x1 x2 x3 a. (SquealEnv db r)
-  => (x1 -> x2 -> x3 -> PQ db db IO a)
-  -> x1 -> x2 -> x3 -> TxM r a
+  :: (x1 -> x2 -> x3 -> PQ db db IO a)
+  -> x1 -> x2 -> x3 -> SquealM db db a
 unsafeSquealIOTxM3 f x1 x2 x3 = unsafeSquealIOTxM $ f x1 x2 x3
 
 unsafeRunSquealTransaction
-  :: forall db r a. (SquealEnv db r)
-  => (PQ db db IO a -> PQ db db IO a)
+  :: forall r a. (SquealEnv r)
+  => (forall db. PQ db db IO a -> PQ db db IO a)
   -> r
   -> TxM r a
   -> IO a
 unsafeRunSquealTransaction f r x = do
-  UnsafeSquealConnection { unsafeWithLibPQConnection } <- unsafeLookupTxEnvIO r
-  unsafeWithLibPQConnection \conn -> do
-    flip Squeal.evalPQ (Squeal.K conn)
-      $ f
-      $ PQ \_ -> Squeal.K <$> unsafeRunTxM r x
+  UnsafeSquealConnection { unsafeGetLibPQConnection } <- unsafeLookupTxEnvIO r
+  conn <- unsafeGetLibPQConnection
+  flip evalPQ (K conn)
+    $ f
+    $ PQ \_ -> K <$> unsafeRunTxM r x
 
 -- $disclaimer
 --

--- a/squeal/src/Database/PostgreSQL/Tx/Squeal/Internal.hs
+++ b/squeal/src/Database/PostgreSQL/Tx/Squeal/Internal.hs
@@ -65,7 +65,7 @@ newtype SquealTxM' (db :: SchemasType) r a =
 -- transaction, so this instance generates a type error when client code tries
 -- to call 'liftIO'.
 --
--- Note that specialize this instance for 'SquealTxM'' rather than derive it
+-- Note that we specialize this instance for 'SquealTxM'' rather than derive it
 -- via newtype so we can provide a better error message.
 --
 -- @since 0.2.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,9 @@
 
 packages:
 - completed:
+    cabal-file:
+      size: 4959
+      sha256: 8891f4eea893607c6e500d73f5f095e11f5bc7c0c20467e6b9040a3e1be039a5
     name: postgresql-query
     version: 3.5.0
     git: https://github.com/Simspace/postgresql-query


### PR DESCRIPTION
Squeal wants to carry around its schema type information with it in the monad. Currently, **postgresql-tx** supports this by including a `data SquealSchemas db` proxy-like value in the runtime environment (the `r` in `TxM r`). This makes type inference break and you end up needing to use `TypeApplications` so GHC knows which schemas to check for.

This PR proposes getting rid of `SquealSchemas`. Instead of requiring schema type metadata in the runtime environment, we include it upfront via `newtype SquealTxM db0 db1 r a` which wraps `TxM r a`, effectively _tagging_ a `TxM` with the schemas `db0` and `db1`. We can then easily _tag_ a `TxM` using the `SquealTxM` constructor or _untag_ it with the `fromSquealTxM` function.

In practice, you probably want to just wrap squeal blocks in `fromSquealTxM`. See the tests for an example of the new usage.