### PR TITLE
Update changelogs for the 0.2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## 0.2.0.0
+
+* Changed the `TxM` encoding from a plain newtype-over-IO to a reader.
+* Removed the `Tx` and `UnsafeTx` type classes.
+* `TxEnv` is now a type class. Added `TxEnvs` for convenience.
+* Added `TxException`.
+* Added the `HEnv` type.
+* Changed module structure so that unsafe functions are provided in an `Unsafe` module.
+
 ## 0.1.0.0
 
 Initial release

--- a/monad-logger/CHANGELOG.md
+++ b/monad-logger/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 0.2.0.0
+
+* Updated for postgresql-tx-0.2.0.0.
+* Added an `Unsafe` module with `unsafeRunLoggerIOInTxM`.
+
 ## 0.1.0.0
 
-Initial release
+* Initial release

--- a/persistent/CHANGELOG.md
+++ b/persistent/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.0.0.0
 
-Development versison - not yet released on Hackage.
+* Development version - not yet released on Hackage.

--- a/query/CHANGELOG.md
+++ b/query/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## 0.2.0.0
+
+* Updated for postgresql-tx-0.2.0.0.
+* Added `HasCallStack` constraints in transaction runners.
+* Added more transaction runners: `pgWithTransactionSerializable`, `pgWithTransactionModeRetry`.
+* Added `pgWithSavepoint`.
+* Added `pgQueryWithMasker`, `pgExecuteWithMasker`.
+* Moved internals to an `Internal` module.
+
 ## 0.1.0.0
 
-Initial release
+* Initial release

--- a/simple/CHANGELOG.md
+++ b/simple/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 0.2.0.0
+
+* Updated for postgresql-tx-0.2.0.0.
+* Added `HasCallStack` constraints in transaction runners.
+* Added more transaction runners: `withTransactionMode`, `withTransactionModeRetry`, `withTransactionSerializable`.
+* Moved internals to an `Internal` module.
+
 ## 0.1.0.0
 
-Initial release
+* Initial release

--- a/squeal/CHANGELOG.md
+++ b/squeal/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## 0.2.0.0
+
+* Updated for postgresql-tx-0.2.0.0.
+* Updated `SquealM` encoding.
+* Added `SquealTxM` and `SquealTxM'`.
+* Updated `transactionallyRetry` to allow for retrying on a predicate.
+* Added `transactionallySerializable`.
+* Moved internals to an `Internal` module.
+
 ## 0.1.0.0
 
-Initial release
+* Initial release

--- a/squeal/compat/simple/CHANGELOG.md
+++ b/squeal/compat/simple/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0.0
 
-Initial release
+* Initial release


### PR DESCRIPTION
No code changes, just changes to the `CHANGELOG`s in preparation for the Hackage release.