### PR TITLE
Remove TxErrorType in favor of an errcode field on TxException

### DIFF
--- a/src/Database/PostgreSQL/Tx.hs
+++ b/src/Database/PostgreSQL/Tx.hs
@@ -15,7 +15,6 @@ module Database.PostgreSQL.Tx
   , throwExceptionTx
   , mapExceptionTx
   , TxException(..)
-  , TxErrorType(..)
   , shouldRetryTx
   ) where
 


### PR DESCRIPTION
The `TxErrorType` was not very future proof. For example, if we added a `TxForeignKeyViolation` constructor and someone had been relying on `TxOtherError (Just "23503")`, we would create a breaking change. It seems better to just provide the `errcode` field directly accessible for inspection.